### PR TITLE
test: add unit coverage for minMaxCheck, killStock, outputType, seed, and pause/continue

### DIFF
--- a/test/continuousGenerator.test.ts
+++ b/test/continuousGenerator.test.ts
@@ -1,0 +1,87 @@
+import { getStockPrices, getContStockPrices, StockPriceOptions } from '../src';
+
+describe('Continuous generator - determinism and validation', () => {
+    const baseOptions: StockPriceOptions = {
+        startPrice: 10000,
+        volatility: 0.1,
+        drift: 0.05,
+        algorithm: 'RandomWalk',
+        interval: 20,
+        seed: 777
+    };
+
+    test('two independent continuous generators with the same seed produce the same price sequence', (done) => {
+        const pricesA: number[] = [];
+        const pricesB: number[] = [];
+
+        const generatorA = getContStockPrices({ ...baseOptions, onPrice: (p) => pricesA.push(p) });
+        const generatorB = getContStockPrices({ ...baseOptions, onPrice: (p) => pricesB.push(p) });
+
+        generatorA.start();
+        generatorB.start();
+
+        setTimeout(() => {
+            generatorA.stop();
+            generatorB.stop();
+
+            expect(pricesA.length).toBeGreaterThan(0);
+            expect(pricesA).toEqual(pricesB);
+            done();
+        }, 200);
+    });
+
+    test('getStockPrices throws synchronously for negative volatility', () => {
+        expect(() => getStockPrices({ startPrice: 10000, length: 5, volatility: -1 })).toThrow(
+            'Volatility must be a non-negative number'
+        );
+    });
+
+    test('getContStockPrices reports the error via onError instead of throwing', (done) => {
+        const onError = jest.fn();
+        const generator = getContStockPrices({
+            ...baseOptions,
+            volatility: -1,
+            onError
+        });
+
+        generator.start();
+
+        setTimeout(() => {
+            generator.stop();
+            expect(onError).toHaveBeenCalledWith(expect.any(Error));
+            done();
+        }, 100);
+    });
+
+    test('pause() stops ticking and continue() resumes it', (done) => {
+        const onPrice = jest.fn();
+        const generator = getContStockPrices({ ...baseOptions, onPrice });
+
+        generator.start();
+
+        setTimeout(() => {
+            generator.pause();
+            const callsAfterPause = onPrice.mock.calls.length;
+            expect(callsAfterPause).toBeGreaterThan(0);
+
+            setTimeout(() => {
+                // No ticks should have happened while paused
+                expect(onPrice.mock.calls.length).toBe(callsAfterPause);
+
+                generator.continue();
+                setTimeout(() => {
+                    generator.stop();
+                    expect(onPrice.mock.calls.length).toBeGreaterThan(callsAfterPause);
+                    done();
+                }, 100);
+            }, 100);
+        }, 100);
+    });
+
+    test('continue() is a no-op while already running', () => {
+        const generator = getContStockPrices(baseOptions);
+        generator.start();
+        expect(() => generator.continue()).not.toThrow();
+        generator.stop();
+    });
+});

--- a/test/killStock.test.ts
+++ b/test/killStock.test.ts
@@ -1,0 +1,27 @@
+import { killStock } from '../src/utils/killStock';
+
+describe('killStock', () => {
+    test('leaves a healthy price untouched', () => {
+        expect(killStock(100)).toBe(100);
+        expect(killStock(0.5)).toBe(0.5);
+    });
+
+    test('zeroes out a price at or below the default near-zero threshold (0.01)', () => {
+        expect(killStock(0.01)).toBe(0);
+        expect(killStock(0.001)).toBe(0);
+        expect(killStock(0)).toBe(0);
+    });
+
+    test('zeroes out a negative price', () => {
+        expect(killStock(-5)).toBe(0);
+    });
+
+    test('leaves a price just above the default threshold untouched', () => {
+        expect(killStock(0.011)).toBe(0.011);
+    });
+
+    test('honors a custom threshold', () => {
+        expect(killStock(5, 10)).toBe(0);
+        expect(killStock(15, 10)).toBe(15);
+    });
+});

--- a/test/minMaxCheck.test.ts
+++ b/test/minMaxCheck.test.ts
@@ -1,0 +1,46 @@
+import { minMaxCheck } from '../src/utils/minMaxCheck';
+
+describe('minMaxCheck', () => {
+    test('returns the price unchanged when min and max are both 0 (unbounded)', () => {
+        expect(minMaxCheck(0, 0, 999999)).toBe(999999);
+        expect(minMaxCheck(0, 0, -999999)).toBe(-999999);
+    });
+
+    test('returns the price unchanged when it already sits within [min, max]', () => {
+        expect(minMaxCheck(9000, 11000, 10000)).toBe(10000);
+    });
+
+    test('pulls a below-min price back up into [min, max]', () => {
+        for (let i = 0; i < 50; i++) {
+            const result = minMaxCheck(9000, 11000, 8000);
+            expect(result).toBeGreaterThanOrEqual(9000);
+            expect(result).toBeLessThanOrEqual(11000);
+        }
+    });
+
+    test('pulls an above-max price back down into [min, max]', () => {
+        for (let i = 0; i < 50; i++) {
+            const result = minMaxCheck(9000, 11000, 12000);
+            expect(result).toBeGreaterThanOrEqual(9000);
+            expect(result).toBeLessThanOrEqual(11000);
+        }
+    });
+
+    test('never returns a value outside [min, max], even for extreme overshoots', () => {
+        for (let i = 0; i < 50; i++) {
+            expect(minMaxCheck(9000, 11000, -1e9)).toBeGreaterThanOrEqual(9000);
+            expect(minMaxCheck(9000, 11000, 1e9)).toBeLessThanOrEqual(11000);
+        }
+    });
+
+    test('clamps to a single point when min equals max', () => {
+        expect(minMaxCheck(10000, 10000, 8000)).toBe(10000);
+        expect(minMaxCheck(10000, 10000, 12000)).toBe(10000);
+    });
+
+    test('respects an effectively min-only bound (large max, small price)', () => {
+        const result = minMaxCheck(9000, 1_000_000, 100);
+        expect(result).toBeGreaterThanOrEqual(9000);
+        expect(result).toBeLessThanOrEqual(1_000_000);
+    });
+});

--- a/test/outputType.test.ts
+++ b/test/outputType.test.ts
@@ -1,0 +1,19 @@
+import { outputType } from '../src/utils/outputType';
+
+describe('outputType', () => {
+    test('rounds to the nearest integer when dataType is "int"', () => {
+        expect(outputType(10.4, 'int')).toBe(10);
+        expect(outputType(10.5, 'int')).toBe(11);
+        expect(Number.isInteger(outputType(10.4, 'int'))).toBe(true);
+    });
+
+    test('rounds to 2 decimal places when dataType is "float"', () => {
+        expect(outputType(10.12345, 'float')).toBe(10.12);
+        expect(outputType(10, 'float')).toBe(10);
+    });
+
+    test('always returns a number', () => {
+        expect(typeof outputType(10.12345, 'float')).toBe('number');
+        expect(typeof outputType(10.6, 'int')).toBe('number');
+    });
+});

--- a/test/seed.test.ts
+++ b/test/seed.test.ts
@@ -1,0 +1,25 @@
+import { seededRandom } from '../src/utils/seed';
+
+describe('seededRandom', () => {
+    test('produces the same value for the same seed', () => {
+        expect(seededRandom(42)).toBe(seededRandom(42));
+        expect(seededRandom(123456789)).toBe(seededRandom(123456789));
+    });
+
+    test('produces different values for different seeds', () => {
+        expect(seededRandom(1)).not.toBe(seededRandom(2));
+    });
+
+    test('always returns a value in [0, 1)', () => {
+        for (const seed of [0, 1, 42, 999, 123456789, -5]) {
+            const value = seededRandom(seed);
+            expect(value).toBeGreaterThanOrEqual(0);
+            expect(value).toBeLessThan(1);
+        }
+    });
+
+    test('falls back to Math.random() (varies between calls) when no seed is given', () => {
+        const values = new Set(Array.from({ length: 5 }, () => seededRandom(undefined)));
+        expect(values.size).toBeGreaterThan(1);
+    });
+});


### PR DESCRIPTION
Related Issue
> Follow-up to #18 / #20 — adds direct unit tests to verify the logic fixed there actually behaves as intended.

Description
> `minMaxCheck`, `killStock`, `outputType`, and `seed` were previously only exercised indirectly through the RandomWalk/GBM integration tests, so a regression in the underlying logic (e.g. the minMax pullback direction, or the delisting threshold) wouldn't necessarily show up as a clear, targeted failure. Added:
>
> - `test/minMaxCheck.test.ts` — unbounded passthrough, in-range passthrough, below-min/above-max pullback always lands in `[min, max]` (including extreme overshoots), `min === max` pinning.
> - `test/killStock.test.ts` — healthy price passthrough, default/custom threshold zeroing, negative price.
> - `test/outputType.test.ts` — int rounding, float 2-decimal rounding, return type.
> - `test/seed.test.ts` — determinism for a given seed, different seeds diverge, output stays in `[0, 1)`, unseeded calls vary.
> - `test/continuousGenerator.test.ts` — two independent continuous generators with the same seed produce identical sequences, `getStockPrices` throws synchronously on invalid volatility vs. `getContStockPrices` routing the same error through `onError`, and `pause()`/`continue()` (previously untested at all).
>
> `src/utils/*` is now at 100% statement/branch/line coverage.

Comments
> All 72 tests pass (`npm test`), `tsc --noEmit` is clean, and `npm run build` succeeds.


---
_Generated by [Claude Code](https://claude.ai/code/session_014j3U4eKAVA4mJv3D8m58BZ)_