### PR TITLE
chore: bump package version to 0.0.23

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,10 +14,10 @@ jobs:
         node-version: [22.x, 24.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Use Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "stockprice-generator",
-  "version": "0.0.20",
+  "version": "0.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "stockprice-generator",
-      "version": "0.0.20",
+      "version": "0.0.23",
       "license": "MIT",
       "devDependencies": {
         "@types/jest": "^30.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "stockprice-generator",
   "description": "A package for generating synthetic stock price data using various random algorithm models",
-  "version": "0.0.20",
+  "version": "0.0.23",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Related Issue
> Follow-up to #18 / #20 / #21

Description
> `package.json`'s `version` field (`0.0.20`) had drifted behind what's already published on npm (`0.0.22`). Bumping to `0.0.23` (patch — no public API changes) so a future `npm publish` doesn't collide with the already-published version, and to version the recent minMax/delisting/continuous-generator bugfixes (#18, #20) plus the new unit test coverage (#21).
>
> Also bumped `actions/checkout@v4` → `@v7` and `actions/setup-node@v4` → `@v6` in `.github/workflows/test.yaml` to clear the "Node.js 20 is deprecated" CI warning (those actions' own runtime was still on Node 20; unrelated to the `node-version` test matrix of 22.x/24.x, which is what's actually being tested).

Comments
> `npm test` (72 passing) and `npm run build` both succeed unchanged.
