### PR TITLE
ci: add npm publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,33 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Use Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.x
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Publish to npm
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Related Issue
> none

Description
> Adds `.github/workflows/publish.yaml` to automate `npm publish`:
> - Triggers on a published GitHub Release, or manually via `workflow_dispatch`.
> - Runs `npm ci` + `npm test` before publishing, so a broken build can't ship.
> - Publishes with `--provenance` (npm's supply-chain attestation), using the workflow's OIDC token (`id-token: write`).
>
> **Setup needed before this can actually publish**: add an `NPM_TOKEN` repository secret (Settings → Secrets and variables → Actions) containing an npm **Automation** access token for an account with publish rights on `stockprice-generator`. Without it, the publish step will fail with an auth error — everything else (checkout, build, tests) will still run fine.
>
> To use it: bump `package.json`'s `version`, merge, then cut a GitHub Release (or run the workflow manually) to publish.

Comments
> Workflow YAML validated with a plain YAML parser; not otherwise executable/testable outside of a real Release trigger with a real `NPM_TOKEN`.


---
_Generated by [Claude Code](https://claude.ai/code/session_014j3U4eKAVA4mJv3D8m58BZ)_