### PR TITLE
fix: validate startPrice, length, and min/max before generating prices

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import { algorithms } from './utils/algorithm/algorithms';
 import type { Algorithm as AlgorithmType } from './utils/algorithm/algorithms';
 import { minMaxCheck } from './utils/minMaxCheck';
 import { killStock } from './utils/killStock';
+import { validateOptions } from './utils/validateOptions';
 
 interface NextPriceParams {
   currentPrice: number;
@@ -46,6 +47,8 @@ class StockPriceGeneratorImpl implements StockPriceGenerator {
   private tick: number; // Number of prices generated so far, used to advance the seed
 
   constructor(options: StockPriceOptions) {
+    validateOptions(options);
+
     this.options = {
       volatility: 0.1,
       drift: 0.05,
@@ -146,6 +149,8 @@ class StockPriceGeneratorImpl implements StockPriceGenerator {
 }
 
 export function getStockPrices(options: StockPriceOptions): StockPriceResult {
+  validateOptions(options);
+
   const {
     startPrice,
     length = 100,

--- a/src/utils/validateOptions.ts
+++ b/src/utils/validateOptions.ts
@@ -1,0 +1,23 @@
+// Structural option errors (bad startPrice/length/min-max) fail fast and synchronously,
+// unlike per-tick algorithm errors (e.g. negative volatility) which surface later via onError.
+export interface ValidatableOptions {
+    startPrice: number;
+    length?: number;
+    min?: number;
+    max?: number;
+}
+
+export function validateOptions({ startPrice, length, min = 0, max = 0 }: ValidatableOptions): void {
+    if (startPrice < 0) {
+        throw new Error('startPrice must be a non-negative number');
+    }
+
+    if (length !== undefined && length <= 0) {
+        throw new Error('length must be a positive integer');
+    }
+
+    // (0, 0) is the documented "unbounded" sentinel, not a real min>max misconfiguration.
+    if (!(min === 0 && max === 0) && min > max) {
+        throw new Error('min must not be greater than max');
+    }
+}

--- a/test/validateOptions.test.ts
+++ b/test/validateOptions.test.ts
@@ -1,0 +1,38 @@
+import { getStockPrices, getContStockPrices } from '../src';
+
+describe('input validation', () => {
+    test('throws for a negative startPrice', () => {
+        expect(() => getStockPrices({ startPrice: -1, length: 5 })).toThrow(
+            'startPrice must be a non-negative number'
+        );
+        expect(() => getContStockPrices({ startPrice: -1 })).toThrow(
+            'startPrice must be a non-negative number'
+        );
+    });
+
+    test('throws for a zero or negative length', () => {
+        expect(() => getStockPrices({ startPrice: 100, length: 0 })).toThrow(
+            'length must be a positive integer'
+        );
+        expect(() => getStockPrices({ startPrice: 100, length: -5 })).toThrow(
+            'length must be a positive integer'
+        );
+    });
+
+    test('throws when min is greater than max', () => {
+        expect(() => getStockPrices({ startPrice: 100, length: 5, min: 200, max: 100 })).toThrow(
+            'min must not be greater than max'
+        );
+        expect(() => getContStockPrices({ startPrice: 100, min: 200, max: 100 })).toThrow(
+            'min must not be greater than max'
+        );
+    });
+
+    test('does not throw for the (0, 0) unbounded min/max sentinel', () => {
+        expect(() => getStockPrices({ startPrice: 100, length: 5, min: 0, max: 0 })).not.toThrow();
+    });
+
+    test('does not throw for valid options', () => {
+        expect(() => getStockPrices({ startPrice: 100, length: 5, min: 50, max: 150 })).not.toThrow();
+    });
+});


### PR DESCRIPTION
## Description
Only `volatility < 0` was rejected before. Negative `startPrice`, `length <= 0`, and `min > max` were accepted silently and produced degenerate output (bogus clamping math, truncated arrays, negative price series).

## Changes
- Added `src/utils/validateOptions.ts`, a pure function invoked from both `getStockPrices` and `getContStockPrices`
- Throws a clear `Error` for:
  - `startPrice < 0`
  - `length <= 0` (when provided)
  - `min > max` (excluding the documented `(0, 0)` unbounded sentinel)
- Added `test/validateOptions.test.ts` covering each branch

Closes #25

## Test plan
- [x] `npm run build`
- [x] `npm test` (82/82 passing)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CC58yHpzzcZzuXtoEmfaA8)_