### PR TITLE
feat: add Ornstein-Uhlenbeck and jump-diffusion algorithms

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,36 @@ const b = getStockPrices({ startPrice: 10000, length: 50, seed: 42 });
 // a.data and b.data are identical
 ```
 
+### Mean-reverting series (OU)
+```javascript
+import { getStockPrices } from 'stockprice-generator';
+
+// The price drifts back toward longTermMean instead of wandering freely
+const result = getStockPrices({
+    startPrice: 10000,
+    length: 250,
+    algorithm: 'OU',
+    longTermMean: 9500,
+    reversionSpeed: 0.5,
+    volatility: 0.2
+});
+```
+
+### Jump-diffusion series (sudden spikes/crashes)
+```javascript
+import { getStockPrices } from 'stockprice-generator';
+
+// Standard GBM diffusion plus occasional jumps
+const result = getStockPrices({
+    startPrice: 10000,
+    length: 250,
+    algorithm: 'JumpDiffusion',
+    jumpIntensity: 5,
+    jumpMean: 0,
+    jumpVolatility: 0.3
+});
+```
+
 ### Discretized integer prices (step + dataType)
 ```javascript
 import { getStockPrices } from 'stockprice-generator';
@@ -176,9 +206,20 @@ const result = getStockPrices({
 | `delisting`  | No       |boolean|false| Force the price to 0 once it falls to or below a near-zero threshold |
 | `step`       | No       | number          | -      | Step size for discretization                                      |
 | `dataType`   | No       | float \| int    | float  | Type of the output data type                                      |
-| `algorithm`  | No       | RandomWalk \| GBM | RandomWalk  | Algorithm for generating the random number                        |
+| `algorithm`  | No       | RandomWalk \| GBM \| OU \| JumpDiffusion | RandomWalk  | Algorithm for generating the random number                |
+| `longTermMean` | No     | number          | `startPrice` | `OU` only: the level the price reverts toward                |
+| `reversionSpeed` | No   | number          | 0.15   | `OU` only: how strongly the price is pulled back toward `longTermMean` |
+| `jumpIntensity` | No    | number          | 1      | `JumpDiffusion` only: expected number of jumps per year               |
+| `jumpMean`   | No       | number          | 0      | `JumpDiffusion` only: mean log-size of a jump                     |
+| `jumpVolatility` | No   | number          | 0.1    | `JumpDiffusion` only: volatility of the jump log-size             |
 
 > `min` and `max` only take effect when at least one of them is non-zero; leaving both at the default `0` means no bounds are enforced.
+
+## Algorithms
+- **RandomWalk**: simple random walk with drift and volatility
+- **GBM**: Geometric Brownian Motion, the standard continuous-time model for stock prices
+- **OU**: Ornstein-Uhlenbeck, a mean-reverting model that pulls the price back toward `longTermMean`
+- **JumpDiffusion**: Merton jump-diffusion — GBM plus occasional Poisson-driven jumps for spikes/crashes
 
 ## Handler Functions (only for continuous generation)
 

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "simulation",
     "random-walk",
     "GBM",
+    "ornstein-uhlenbeck",
+    "jump-diffusion",
     "finance"
   ],
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,19 +16,54 @@ interface NextPriceParams {
   delisting: boolean;
   dataType: DataType;
   step?: number;
+  longTermMean?: number;
+  reversionSpeed?: number;
+  jumpIntensity?: number;
+  jumpMean?: number;
+  jumpVolatility?: number;
 }
 
 // Single source of truth for "what's the next price" used by both the one-shot
 // array generator and the continuous generator, so the two APIs can't drift apart.
 function computeNextPrice(params: NextPriceParams): number {
-  const { currentPrice, volatility, drift, algorithm, seed, min, max, delisting, dataType, step } = params;
+  const {
+    currentPrice,
+    volatility,
+    drift,
+    algorithm,
+    seed,
+    min,
+    max,
+    delisting,
+    dataType,
+    step,
+    longTermMean,
+    reversionSpeed,
+    jumpIntensity,
+    jumpMean,
+    jumpVolatility
+  } = params;
 
   if (volatility < 0) {
     throw new Error('Volatility must be a non-negative number');
   }
 
   const selectedAlgorithm = algorithms[algorithm];
-  let nextPrice = selectedAlgorithm({ currentPrice, volatility, drift, seed, min, max, delisting, dataType });
+  let nextPrice = selectedAlgorithm({
+    currentPrice,
+    volatility,
+    drift,
+    seed,
+    min,
+    max,
+    delisting,
+    dataType,
+    longTermMean,
+    reversionSpeed,
+    jumpIntensity,
+    jumpMean,
+    jumpVolatility
+  });
 
   // Apply step size discretization if specified
   if (step && step > 0) {
@@ -77,7 +112,12 @@ class StockPriceGeneratorImpl implements StockPriceGenerator {
       min = 0,
       max = 0,
       delisting = false,
-      dataType = 'float'
+      dataType = 'float',
+      longTermMean,
+      reversionSpeed,
+      jumpIntensity,
+      jumpMean,
+      jumpVolatility
     } = this.options;
 
     // Advance the seed every tick; otherwise a fixed seed would make every
@@ -94,7 +134,12 @@ class StockPriceGeneratorImpl implements StockPriceGenerator {
       max,
       delisting,
       dataType,
-      step
+      step,
+      longTermMean: longTermMean ?? this.options.startPrice,
+      reversionSpeed,
+      jumpIntensity,
+      jumpMean,
+      jumpVolatility
     });
   }
 
@@ -162,7 +207,12 @@ export function getStockPrices(options: StockPriceOptions): StockPriceResult {
     max = 0,
     delisting = false,
     dataType = 'float',
-    step
+    step,
+    longTermMean,
+    reversionSpeed,
+    jumpIntensity,
+    jumpMean,
+    jumpVolatility
   } = options;
 
   let currentPrice = delisting ? killStock(startPrice) : minMaxCheck(min, max, startPrice);
@@ -179,7 +229,12 @@ export function getStockPrices(options: StockPriceOptions): StockPriceResult {
       max,
       delisting,
       dataType,
-      step
+      step,
+      longTermMean: longTermMean ?? startPrice,
+      reversionSpeed,
+      jumpIntensity,
+      jumpMean,
+      jumpVolatility
     });
     data.push(currentPrice);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,11 @@ export interface StockPriceOptions {
   step?: number; // Step size for the generated data
   dataType?: DataType; // Type of data to generate (float or int)
   algorithm?: Algorithm; // Algorithm to use for generating stock prices
+  longTermMean?: number; // OU only: level the price reverts toward (defaults to startPrice)
+  reversionSpeed?: number; // OU only: how fast the price pulls back toward longTermMean
+  jumpIntensity?: number; // JumpDiffusion only: expected number of jumps per year
+  jumpMean?: number; // JumpDiffusion only: mean log-size of a jump
+  jumpVolatility?: number; // JumpDiffusion only: volatility of the jump log-size
   interval?: number; // Interval for generating stock prices (in milliseconds)
   onStart?: () => void; // Callback for when the generator starts
   onPrice?: (price: number, previousPrice: number | null) => void; // Callback for each generated price

--- a/src/utils/algorithm/algorithmParams.ts
+++ b/src/utils/algorithm/algorithmParams.ts
@@ -9,4 +9,9 @@ export interface AlgorithmParams {
     max?: number; // Maximum stock price
     delisting?: boolean; // Keep stock price to 0 if it reaches 0
     dataType?: DataType; // Type of data to generate (float or int)
+    longTermMean?: number; // OU: level the price reverts toward (defaults to startPrice)
+    reversionSpeed?: number; // OU: how fast the price pulls back toward longTermMean
+    jumpIntensity?: number; // JumpDiffusion: expected number of jumps per year
+    jumpMean?: number; // JumpDiffusion: mean log-size of a jump
+    jumpVolatility?: number; // JumpDiffusion: volatility of the jump log-size
 }

--- a/src/utils/algorithm/algorithms.ts
+++ b/src/utils/algorithm/algorithms.ts
@@ -1,9 +1,13 @@
 import { GBM } from './useGBM';
 import { RandomWalk } from './useRandomWalk';
+import { OU } from './useOU';
+import { JumpDiffusion } from './useJumpDiffusion';
 
 export const algorithms = {
     RandomWalk: RandomWalk,
-    GBM: GBM
+    GBM: GBM,
+    OU: OU,
+    JumpDiffusion: JumpDiffusion
 } as const;
 
 export type Algorithm = keyof typeof algorithms;

--- a/src/utils/algorithm/useJumpDiffusion.ts
+++ b/src/utils/algorithm/useJumpDiffusion.ts
@@ -1,0 +1,44 @@
+import type { AlgorithmParams } from './algorithmParams';
+import { seededRandom } from '../seed';
+import { minMaxCheck } from '../minMaxCheck';
+import { killStock } from '../killStock';
+import { outputType } from '../outputType';
+
+// Merton jump-diffusion: standard GBM diffusion plus an occasional Poisson-driven jump,
+// so the series can spike/crash instead of only ever drifting smoothly like GBM.
+export function JumpDiffusion({ currentPrice, volatility = 0.1, drift = 0.05, seed, min = 0, max = 0, delisting = false, dataType = 'float', jumpIntensity = 1, jumpMean = 0, jumpVolatility = 0.1 }: AlgorithmParams): number {
+    const dt = 1 / 365;
+
+    const u1 = seededRandom(seed);
+    const u2 = seededRandom(seed !== undefined ? seed + 1 : undefined); // ensure different seed
+    const z = Math.sqrt(-2.0 * Math.log(u1)) * Math.cos(2.0 * Math.PI * u2); // standard normal
+
+    const diffusion = Math.exp(
+        (drift - 0.5 * volatility * volatility) * dt +
+        volatility * Math.sqrt(dt) * z
+    );
+
+    // A jump fires this tick with probability jumpIntensity * dt (Poisson thinning for small dt).
+    const jumpDraw = seededRandom(seed !== undefined ? seed + 2 : undefined);
+    let jump = 1;
+    if (jumpDraw < jumpIntensity * dt) {
+        const j1 = seededRandom(seed !== undefined ? seed + 3 : undefined);
+        const j2 = seededRandom(seed !== undefined ? seed + 4 : undefined);
+        const jumpZ = Math.sqrt(-2.0 * Math.log(j1)) * Math.cos(2.0 * Math.PI * j2);
+        jump = Math.exp(jumpMean + jumpVolatility * jumpZ);
+    }
+
+    let nextPrice = currentPrice * diffusion * jump;
+
+    // Check if delisting is enabled
+    if (delisting) {
+        // Delisting logic
+        nextPrice = killStock(nextPrice);
+    } else {
+        // Check min and max limits
+        nextPrice = minMaxCheck(min, max, nextPrice);
+    }
+
+    // Output with specified data type
+    return outputType(nextPrice, dataType);
+}

--- a/src/utils/algorithm/useOU.ts
+++ b/src/utils/algorithm/useOU.ts
@@ -1,0 +1,34 @@
+import type { AlgorithmParams } from './algorithmParams';
+import { seededRandom } from '../seed';
+import { minMaxCheck } from '../minMaxCheck';
+import { killStock } from '../killStock';
+import { outputType } from '../outputType';
+
+// Ornstein-Uhlenbeck applied to log-price: dX = reversionSpeed * (ln(longTermMean) - X) * dt + volatility * sqrt(dt) * dW,
+// then nextPrice = exp(X + dX). Working in log-space keeps volatility/reversionSpeed on the same relative
+// scale as GBM/RandomWalk (instead of a fixed-dollar move) and keeps the price positive between ticks.
+export function OU({ currentPrice, volatility = 0.1, longTermMean, reversionSpeed = 0.15, seed, min = 0, max = 0, delisting = false, dataType = 'float' }: AlgorithmParams): number {
+    const dt = 1 / 365;
+    const mu = Math.max(longTermMean ?? currentPrice, Number.EPSILON);
+
+    const u1 = seededRandom(seed);
+    const u2 = seededRandom(seed !== undefined ? seed + 1 : undefined); // ensure different seed
+    const z = Math.sqrt(-2.0 * Math.log(u1)) * Math.cos(2.0 * Math.PI * u2); // standard normal
+
+    const logCurrent = Math.log(Math.max(currentPrice, Number.EPSILON));
+    const logChange = reversionSpeed * (Math.log(mu) - logCurrent) * dt + volatility * Math.sqrt(dt) * z;
+
+    let nextPrice = Math.exp(logCurrent + logChange);
+
+    // Check if delisting is enabled
+    if (delisting) {
+        // Delisting logic
+        nextPrice = killStock(nextPrice);
+    } else {
+        // Check min and max limits
+        nextPrice = minMaxCheck(min, max, nextPrice);
+    }
+
+    // Output with specified data type
+    return outputType(nextPrice, dataType);
+}

--- a/test/useJumpDiffusion.test.ts
+++ b/test/useJumpDiffusion.test.ts
@@ -1,0 +1,101 @@
+import { getStockPrices, getContStockPrices, StockPriceOptions } from '../src';
+
+describe('JumpDiffusion Algorithm - Stock Price Generator', () => {
+    const defaultOptions: StockPriceOptions = {
+        startPrice: 10000,
+        length: 10,
+        volatility: 0.1,
+        drift: 0.05,
+        algorithm: 'JumpDiffusion'
+    };
+
+    test('should return correct data structure', () => {
+        const result = getStockPrices(defaultOptions);
+        expect(result).toHaveProperty('data');
+        expect(result).toHaveProperty('price');
+        expect(Array.isArray(result.data)).toBe(true);
+        expect(typeof result.price).toBe('number');
+    });
+
+    test('should generate correct number of length', () => {
+        const result = getStockPrices(defaultOptions);
+        expect(result.data.length).toBe(defaultOptions.length);
+    });
+
+    test('should use provided seed for reproducibility', () => {
+        const result1 = getStockPrices({ ...defaultOptions, seed: 123 });
+        const result2 = getStockPrices({ ...defaultOptions, seed: 123 });
+        expect(result1.data).toEqual(result2.data);
+    });
+
+    test('should start with the specified startPrice', () => {
+        const result = getStockPrices({ ...defaultOptions, startPrice: 12345 });
+        expect(result.data[0]).toBe(12345);
+    });
+
+    test('should produce larger jumps in the series when jumpIntensity is high', () => {
+        const calm = getStockPrices({
+            ...defaultOptions,
+            length: 200,
+            jumpIntensity: 0,
+            seed: 55
+        });
+        const jumpy = getStockPrices({
+            ...defaultOptions,
+            length: 200,
+            jumpIntensity: 500,
+            jumpVolatility: 0.5,
+            seed: 55
+        });
+
+        const maxStep = (data: number[]) =>
+            Math.max(...data.slice(1).map((p, i) => Math.abs(Math.log(p / data[i]))));
+
+        expect(maxStep(jumpy.data)).toBeGreaterThan(maxStep(calm.data));
+    });
+
+    test('should respect min and max bounds', () => {
+        const result = getStockPrices({
+            ...defaultOptions,
+            length: 100,
+            jumpIntensity: 50,
+            min: 9000,
+            max: 11000
+        });
+
+        expect(Math.min(...result.data)).toBeGreaterThanOrEqual(9000);
+        expect(Math.max(...result.data)).toBeLessThanOrEqual(11000);
+    });
+
+    test('should round prices to integers if dataType is int', () => {
+        const result = getStockPrices({ ...defaultOptions, dataType: 'int' });
+        expect(result.data.every(price => Number.isInteger(price))).toBe(true);
+    });
+
+    test('should apply delisting logic when price collapses', () => {
+        const result = getStockPrices({
+            ...defaultOptions,
+            startPrice: 1,
+            volatility: 10,
+            drift: -500,
+            delisting: true,
+            seed: 999
+        });
+
+        expect(result.data.some(p => p <= 0)).toBe(true);
+    });
+
+    test('should support the JumpDiffusion algorithm with a continuous generator', (done) => {
+        const generator = getContStockPrices({ ...defaultOptions, interval: 100 });
+        const initialPrice = generator.getCurrentPrice();
+        generator.start();
+
+        setTimeout(() => {
+            const newPrice = generator.getCurrentPrice();
+            expect(typeof newPrice).toBe('number');
+            expect(newPrice).not.toBe(initialPrice);
+            generator.stop();
+            done();
+        }, 250);
+    });
+});

--- a/test/useOU.test.ts
+++ b/test/useOU.test.ts
@@ -1,0 +1,111 @@
+import { getStockPrices, getContStockPrices, StockPriceOptions } from '../src';
+
+describe('OU (Ornstein-Uhlenbeck) Algorithm - Stock Price Generator', () => {
+    const defaultOptions: StockPriceOptions = {
+        startPrice: 10000,
+        length: 10,
+        volatility: 0.1,
+        algorithm: 'OU'
+    };
+
+    test('should return correct data structure', () => {
+        const result = getStockPrices(defaultOptions);
+        expect(result).toHaveProperty('data');
+        expect(result).toHaveProperty('price');
+        expect(Array.isArray(result.data)).toBe(true);
+        expect(typeof result.price).toBe('number');
+    });
+
+    test('should generate correct number of length', () => {
+        const result = getStockPrices(defaultOptions);
+        expect(result.data.length).toBe(defaultOptions.length);
+    });
+
+    test('should use provided seed for reproducibility', () => {
+        const result1 = getStockPrices({ ...defaultOptions, seed: 123 });
+        const result2 = getStockPrices({ ...defaultOptions, seed: 123 });
+        expect(result1.data).toEqual(result2.data);
+    });
+
+    test('should start with the specified startPrice', () => {
+        const result = getStockPrices({ ...defaultOptions, startPrice: 12345 });
+        expect(result.data[0]).toBe(12345);
+    });
+
+    test('should revert toward longTermMean over a long series', () => {
+        const result = getStockPrices({
+            startPrice: 20000,
+            length: 2000,
+            volatility: 0.2,
+            algorithm: 'OU',
+            longTermMean: 10000,
+            reversionSpeed: 2,
+            seed: 42
+        });
+
+        const last200 = result.data.slice(-200);
+        const avgOfTail = last200.reduce((a, b) => a + b, 0) / last200.length;
+
+        // Started far above the mean; a strongly mean-reverting series should end up much closer to it.
+        expect(Math.abs(avgOfTail - 10000)).toBeLessThan(Math.abs(20000 - 10000));
+    });
+
+    test('should default longTermMean to startPrice when not provided', () => {
+        const result = getStockPrices({
+            startPrice: 10000,
+            length: 500,
+            volatility: 0.05,
+            algorithm: 'OU',
+            reversionSpeed: 2,
+            seed: 7
+        });
+
+        const avg = result.data.reduce((a, b) => a + b, 0) / result.data.length;
+        expect(Math.abs(avg - 10000)).toBeLessThan(2000);
+    });
+
+    test('should respect min and max bounds', () => {
+        const result = getStockPrices({
+            ...defaultOptions,
+            length: 100,
+            min: 9000,
+            max: 11000
+        });
+
+        expect(Math.min(...result.data)).toBeGreaterThanOrEqual(9000);
+        expect(Math.max(...result.data)).toBeLessThanOrEqual(11000);
+    });
+
+    test('should round prices to integers if dataType is int', () => {
+        const result = getStockPrices({ ...defaultOptions, dataType: 'int' });
+        expect(result.data.every(price => Number.isInteger(price))).toBe(true);
+    });
+
+    test('should apply delisting logic when price collapses', () => {
+        const result = getStockPrices({
+            ...defaultOptions,
+            length: 20,
+            startPrice: 1,
+            longTermMean: 0.0001,
+            reversionSpeed: 50,
+            delisting: true,
+            seed: 999
+        });
+
+        expect(result.data.some(p => p <= 0)).toBe(true);
+    });
+
+    test('should support the OU algorithm with a continuous generator', (done) => {
+        const generator = getContStockPrices({ ...defaultOptions, interval: 100 });
+        const initialPrice = generator.getCurrentPrice();
+        generator.start();
+
+        setTimeout(() => {
+            const newPrice = generator.getCurrentPrice();
+            expect(typeof newPrice).toBe('number');
+            expect(newPrice).not.toBe(initialPrice);
+            generator.stop();
+            done();
+        }, 250);
+    });
+});


### PR DESCRIPTION
## Description
Only `RandomWalk` and `GBM` existed. The algorithm layer is already pure functions behind a common `AlgorithmParams` interface (`src/utils/algorithm/`), so this adds two more models that plug into the same interface.

## Changes
- **`OU`** (Ornstein-Uhlenbeck, mean-reverting): applied in log-price space (`dX = θ(ln(μ) - X)dt + σ√dt·dW`, then `nextPrice = exp(X + dX)`) so `volatility`/`reversionSpeed` stay on the same relative scale as GBM instead of a fixed-dollar move, and the price can't go non-positive between ticks. Reverts toward `longTermMean` (defaults to `startPrice`) at `reversionSpeed` (default `0.15`).
- **`JumpDiffusion`** (Merton jump-diffusion): standard GBM diffusion plus an occasional Poisson-driven jump, controlled by `jumpIntensity` (expected jumps/year, default `1`), `jumpMean`, and `jumpVolatility` (default `0.1`).
- Both registered in `src/utils/algorithm/algorithms.ts`; all new options are optional additions to `StockPriceOptions`/`AlgorithmParams`, so existing configs are unaffected.
- Added `test/useOU.test.ts` and `test/useJumpDiffusion.test.ts` mirroring the existing GBM/RandomWalk coverage.
- Updated the README parameter table, algorithm list, and added two usage examples.

Closes #29

## Test plan
- [x] `npm run build`
- [x] `npm test` (101/101 passing)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CC58yHpzzcZzuXtoEmfaA8)_