### PR TITLE
fix: replace setInterval with recursive setTimeout in continuous generator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ class StockPriceGeneratorImpl implements StockPriceGenerator {
   private currentPrice: number; // Current stock price
   private previousPrice: number | null; // Price before the current one
   private readonly interval: number; // Interval in milliseconds
-  private timer: ReturnType<typeof setInterval> | null; // Timer ID
+  private timer: ReturnType<typeof setTimeout> | null; // Timer ID
   private readonly options: StockPriceOptions; // Options for the generator
   private tick: number; // Number of prices generated so far, used to advance the seed
 
@@ -98,10 +98,13 @@ class StockPriceGeneratorImpl implements StockPriceGenerator {
     });
   }
 
+  // A recursive setTimeout is used instead of setInterval so each tick is scheduled
+  // relative to when the previous one actually finished, avoiding both long-run drift
+  // and pile-ups if a tick (or the event loop) is delayed.
   private runTimer(): void {
     if (this.timer) return;
 
-    this.timer = setInterval(() => {
+    const tick = (): void => {
       try {
         const nextPrice = this.generateNextPrice();
         this.previousPrice = this.currentPrice;
@@ -110,7 +113,10 @@ class StockPriceGeneratorImpl implements StockPriceGenerator {
       } catch (error) {
         this.options.onError?.(error as Error);
       }
-    }, this.interval);
+      this.timer = setTimeout(tick, this.interval);
+    };
+
+    this.timer = setTimeout(tick, this.interval);
   }
 
   start(): void {
@@ -121,7 +127,7 @@ class StockPriceGeneratorImpl implements StockPriceGenerator {
 
   pause(): void {
     if (this.timer) {
-      clearInterval(this.timer);
+      clearTimeout(this.timer);
       this.timer = null;
     }
   }
@@ -132,7 +138,7 @@ class StockPriceGeneratorImpl implements StockPriceGenerator {
 
   stop(): void {
     if (this.timer) {
-      clearInterval(this.timer);
+      clearTimeout(this.timer);
       this.timer = null;
       this.options.onStop?.();
       this.options.onComplete?.();

--- a/test/continuousGenerator.test.ts
+++ b/test/continuousGenerator.test.ts
@@ -84,4 +84,41 @@ describe('Continuous generator - determinism and validation', () => {
         expect(() => generator.continue()).not.toThrow();
         generator.stop();
     });
+
+    test('does not schedule the next tick until a slow onPrice callback returns', (done) => {
+        const tickTimestamps: number[] = [];
+        const slowTickInterval = 30;
+        const onPriceDelay = 80; // longer than the interval, so overlap would show up as bunched-up timestamps
+
+        const generator = getContStockPrices({
+            ...baseOptions,
+            interval: slowTickInterval,
+            onPrice: () => {
+                tickTimestamps.push(Date.now());
+                // Busy-wait synchronously to simulate slow (blocking) work in onPrice.
+                const until = Date.now() + onPriceDelay;
+                while (Date.now() < until) {
+                    /* noop */
+                }
+            }
+        });
+
+        generator.start();
+
+        setTimeout(() => {
+            generator.stop();
+
+            expect(tickTimestamps.length).toBeGreaterThanOrEqual(2);
+
+            for (let i = 1; i < tickTimestamps.length; i++) {
+                const gap = tickTimestamps[i] - tickTimestamps[i - 1];
+                // Each tick should wait for the previous onPrice to finish before the next
+                // interval starts counting down, so consecutive ticks can't land closer
+                // together than onPrice's own blocking time.
+                expect(gap).toBeGreaterThanOrEqual(onPriceDelay);
+            }
+
+            done();
+        }, onPriceDelay * 3 + 100);
+    });
 });


### PR DESCRIPTION
## Description
`StockPriceGeneratorImpl` drove ticks with `setInterval`, which fires on a fixed wall-clock cadence regardless of how long the previous tick's callback took. Over a long-running process this compounds drift, and can cause ticks to pile up back-to-back if the event loop was busy.

## Changes
- Replaced `setInterval`/`clearInterval` with a recursive `setTimeout`/`clearTimeout`: the next tick is only scheduled after the current one (including `onPrice`/`onError`) finishes, so spacing is based on actual elapsed time.
- `start()`/`pause()`/`continue()`/`stop()` behavior is unchanged from the caller's perspective.
- Added a test in `test/continuousGenerator.test.ts` that uses a deliberately slow (blocking) `onPrice` callback and asserts consecutive ticks never land closer together than the callback's own blocking time.

Closes #31

## Test plan
- [x] `npm run build`
- [x] `npm test` (83/83 passing)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CC58yHpzzcZzuXtoEmfaA8)_