### PR TITLE
docs: add CONTRIBUTING.md documenting branch and commit conventions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing
+
+Thanks for considering a contribution! This document covers the conventions this
+repository actually follows so you don't have to reverse-engineer them from history.
+
+## Workflow
+
+1. Open (or find) an issue describing the change.
+2. Branch off `main` using the naming convention below.
+3. Commit using [Conventional Commits](#commit-messages) — this is enforced by CI.
+4. Open a pull request against `main`. CI (build, tests, CodeQL, commitlint) must pass.
+5. Once merged, [release-please](.github/workflows/release-please.yaml) opens or updates
+   a release PR that bumps the version and updates `CHANGELOG.md` based on the commits
+   since the last release. Merging that release PR tags the release and publishes to npm.
+
+## Branch naming
+
+```
+<type>#<issue-number>/<short-description>
+```
+
+Examples: `fix#25/input-validation`, `feat#29/algorithm-expansion`, `docs#33/contributing`.
+
+`<type>` matches the [commit type](#commit-messages) of the work the branch contains, and
+`<issue-number>` is the GitHub issue the branch resolves.
+
+## Commit messages
+
+This repository follows [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>: <description>
+```
+
+Commonly used types here: `feat`, `fix`, `chore`, `docs`, `test`, `ci`, `refactor`, `perf`.
+Commit messages are linted on every pull request by the `commitlint` GitHub Action
+(config in `commitlint.config.js`); non-conforming commits will fail CI. You can check
+locally before pushing:
+
+```bash
+npm run commitlint
+```
+
+`feat` and `fix` commits are what drive the automatic version bump — see
+[Version management automation](#workflow) above.
+
+## Before opening a pull request
+
+```bash
+npm run build
+npm test
+```

--- a/README.md
+++ b/README.md
@@ -232,6 +232,9 @@ const result = getStockPrices({
 | `onComplete` | No       | function | -        | Callback function to handle generator completion event                   |
 | `onError` | No       | function | -        | Callback function to handle errors in continuous generation              |
 
+## Contributing
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for branch naming, commit message conventions, and the release process.
+
 ## Security
 This project has no runtime dependencies, and development dependencies are kept up to date and regularly audited with `npm audit`. If you discover a security issue, please open an issue on GitHub.
 


### PR DESCRIPTION
## Description
The `type#issueNumber/description` branch naming and Conventional Commits message format were already followed in practice (and enforced by the commitlint CI check added in #27/#28), but nowhere documented for new contributors.

## Changes
- Add `CONTRIBUTING.md`: workflow (issue → branch → PR → CI → merge → release-please), branch naming convention, commit message convention, and pre-PR checklist.
- Link it from the README.

Closes #33

## Test plan
- [x] `npm run build`
- [x] `npm test` (101/101 passing)


---
_Generated by [Claude Code](https://claude.ai/code/session_01CC58yHpzzcZzuXtoEmfaA8)_